### PR TITLE
Fix login info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This will launch a Cribl demo environment with a number of sources and destinati
 
 | System                 | URL                                                                                                    | Username | Password  |
 |------------------------|--------------------------------------------------------------------------------------------------------|----------|-----------|
-| Cribl                  | http://localhost:9000/login?username=admin&password=cribldemo                                          | admin    | cribldemo |
-| Splunk                 | https://localhost:8000/en-US/account/insecurelogin?loginType=splunk&username=admin&password=cribldemo- | admin    | cribldemo |
+| Cribl                  | http://localhost:9000/                                          | admin    | admin |
+| Splunk                 | https://localhost:8000/en-US/account/insecurelogin?loginType=splunk&username=admin&password=cribldemo | admin    | cribldemo |
 | Elasticsearch (Kibana) | http://localhost:9200                                                                                  |          |           |
 | Grafana                | http://localhost:8200                                                                                  | admin    | cribldemo |
 | Graphite               | http://localhost:8100                                                                                  |          |           |


### PR DESCRIPTION
This PR fixes some incorrect information regarding the logins for Cribl and Splunk:
- The default password for Cribl is *admin* instead of *cribldemo*.
- The *login* parameter in the query string does not work with the provided version of Cribl. That's either a bug or the functionality is not (yet) implemented.
- The query string for the Splunk login contained a `-` character too much which made the login fail.